### PR TITLE
added solution to clang error on macOS

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -165,3 +165,13 @@ may encounter the following error::
     conda install sphinx==1.5.6
 
 Then, ``python setup.py build install`` should run without problems.
+
+**Problem:** When trying to run ``python setup.py develop`` on macOS, the following error popped up::
+
+        unsupported tapi file type '!tapi-tbd' in YAML file '/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/lib/libSystem.tbd' for architecture x86_64
+        clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
+        
+**Solution:** Set ``gcc`` as your standard compiler to replace the default ``clang`` shipped with XCode::
+
+    export CC=gcc
+If gcc is not yet installed on your machine, get homebrew and install it with ``brew install gcc``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added solution to Install error I encountered while using clang as compiler.

## Description
<!--- Describe your changes in detail -->
Added onto the installation.rst under the Troubleshooting FAQ on how to solve clang compiler error by switching main compiler to gcc instead.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tardis is incompatible with the stock clang on macOS therefore the environment variable CC has to point to gcc to change the default behavior.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
python setup.py develop now works on my machine after executing these changes.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
